### PR TITLE
Remove nuget packaging reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 3.0
+dotnet: 6.0
 sudo: false
 env:
     global:

--- a/src/DeepWinter.RRuleParserNet/DeepWinter.RRuleParserNet.csproj
+++ b/src/DeepWinter.RRuleParserNet/DeepWinter.RRuleParserNet.csproj
@@ -27,7 +27,4 @@ RRule parser is a small dotnet library which lets you convert a iCalendar RRule 
     <Folder Include="Text\Formatting\" />
     <Folder Include="Text\Listing\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="5.5.1" />
-  </ItemGroup>
 </Project>

--- a/src/DeepWinter.RRuleParserNet/DeepWinter.RRuleParserNet.csproj
+++ b/src/DeepWinter.RRuleParserNet/DeepWinter.RRuleParserNet.csproj
@@ -6,7 +6,7 @@
     <Authors>Lars Winter</Authors>
     <Copyright>Copyright © 2019 Lars Winter</Copyright>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageLicenseUrl>https://licenses.nuget.org/MIT</PackageLicenseUrl>
+    <License>https://licenses.nuget.org/MIT</License>
     <Owners>Lars Winter</Owners>
     <PackageProjectUrl>https://github.com/Deep-Winter/rrule-parser.net</PackageProjectUrl>
     <Summary>Dotnet port of rrule-parser by aditosoftware.
@@ -16,6 +16,7 @@ RRule parser is a small dotnet library which lets you convert a iCalendar RRule 
     <Description>Dotnet port of rrule-parser by aditosoftware.
 RRule parser is a small dotnet library which lets you convert a iCalendar RRule into human readable text.</Description>
     <PackageVersion>1.0.2</PackageVersion>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,5 +27,8 @@ RRule parser is a small dotnet library which lets you convert a iCalendar RRule 
     <Folder Include="Text\" />
     <Folder Include="Text\Formatting\" />
     <Folder Include="Text\Listing\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hey, just removed a now unneeded nuget package reference and updated the build file to use .net 6. 

https://www.nuget.org/packages/rrule-parser.net/#dependencies-body-tab

Hopefully means that the package no longer shows as requiring Nuget.Packaging.